### PR TITLE
chore: standardize Solidity version to 0.8.24

### DIFF
--- a/FantasyCore.sol
+++ b/FantasyCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.24;
 
 /// ============ INTERFACES============
 interface IERC20 {

--- a/MockUSDC.sol
+++ b/MockUSDC.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.24;
 
 /// @title MockUSDC - minimal 6-decimal ERC20 for testing FantasyCore
 contract MockUSDC {

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,2 @@
+[profile.default]
+solc_version = "0.8.24"


### PR DESCRIPTION
## Summary
- align FantasyCore and MockUSDC contracts on Solidity ^0.8.24
- configure Foundry to use solc 0.8.24

## Testing
- `solcjs --bin FantasyCore.sol GameweekPointsStore.sol MockUSDC.sol -o /tmp/build`


------
https://chatgpt.com/codex/tasks/task_e_68adf053ef6c832090538d40659a3fb0